### PR TITLE
Added case for m4a encoding

### DIFF
--- a/src/model/utils.js
+++ b/src/model/utils.js
@@ -37,6 +37,9 @@ module.exports = {
         case '.wav': {
           return 'MULAW';
         }
+        case '.m4a': {
+          return 'M4A';
+        }
         default: {
           throw new Error('Encoding could not be determined for file: ' + filename);
         }


### PR DESCRIPTION
The detectEncoding function in utils.js returns an error on m4a filetypes even though the api supports m4a. I've added the filetype to the case-switch